### PR TITLE
fix: slice bounds panic in renderNewsContent for multi-byte titles

### DIFF
--- a/ui/model.go
+++ b/ui/model.go
@@ -1071,8 +1071,8 @@ func (m Model) renderNewsContent() (string, int) {
 
 		// Truncate title to fit exactly one line
 		titleLine := item.Title
-		if len(titleLine) > titleW {
-			runes := []rune(titleLine)
+		runes := []rune(titleLine)
+		if len(runes) > titleW {
 			titleLine = string(runes[:titleW-1]) + "…"
 		}
 		urlIndicator := ""


### PR DESCRIPTION
## Summary

- Fixes a panic (`slice bounds out of range`) in `renderNewsContent` when news titles contain multi-byte characters (accented letters, emojis, CJK characters)
- Root cause: `len(titleLine)` checks **byte length** but `runes[:titleW-1]` slices by **rune count** — when byte length exceeds `titleW` but rune count is smaller, the slice overflows
- Fix: convert to runes first, then compare `len(runes)` against `titleW`

## Test plan

- [ ] Run watchtower with RSS feeds that include non-ASCII titles (e.g. accented characters, emojis)
- [ ] Resize terminal to various widths to trigger title truncation
- [ ] Verify no panic occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)