### PR TITLE
feat: add OpenRouter as LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ go install github.com/lajosdeme/watchtower@latest
 
 On first run, Watchtower will prompt you to configure a few things:
 
-1. **Select LLM provider** — Choose Groq (free), OpenAI, Deepseek, Gemini, or Anthropic, or local model
+1. **Select LLM provider** — Choose Groq (free), OpenAI, Deepseek, Gemini, Anthropic, OpenRouter, or local model
 2. **Paste your API key** — Stored locally in `~/.config/watchtower/config.yaml`, never leaves your device
 3. **Specify your location** — Enter your city and coordinates for local weather and news
 
@@ -111,7 +111,7 @@ That's it! The app saves your settings and you're ready to go.
 | Polymarket | Prediction markets | None (public API) |
 | Yahoo Finance | Stocks & commodities | None |
 | Open-Meteo | Weather | None |
-| Groq / OpenAI / Anthropic / Deepseek / Gemini / Local | AI brief | Required (free tiers available) |
+| Groq / OpenAI / Anthropic / Deepseek / Gemini / OpenRouter / Local | AI brief | Required (free tiers available) |
 
 ## Tech Stack
 

--- a/intel/intel.go
+++ b/intel/intel.go
@@ -16,12 +16,13 @@ import (
 type Provider string
 
 const (
-	ProviderGroq     Provider = "groq"
-	ProviderOpenAI   Provider = "openai"
-	ProviderDeepSeek Provider = "deepseek"
-	ProviderGemini   Provider = "gemini"
-	ProviderClaude   Provider = "claude"
-	ProviderLocal    Provider = "local"
+	ProviderGroq      Provider = "groq"
+	ProviderOpenAI    Provider = "openai"
+	ProviderDeepSeek  Provider = "deepseek"
+	ProviderGemini    Provider = "gemini"
+	ProviderClaude    Provider = "claude"
+	ProviderLocal     Provider = "local"
+	ProviderOpenRouter Provider = "openrouter"
 )
 
 var providerDefaults = map[Provider]struct {
@@ -63,6 +64,12 @@ var providerDefaults = map[Provider]struct {
 	ProviderLocal: {
 		endpoint:     "http://localhost:11434/v1/chat/completions",
 		defaultModel: "llama3",
+		authHeader:   "Authorization",
+		authPrefix:   "Bearer ",
+	},
+	ProviderOpenRouter: {
+		endpoint:     "https://openrouter.ai/api/v1/chat/completions",
+		defaultModel: "openai/chatgpt-4o-latest",
 		authHeader:   "Authorization",
 		authPrefix:   "Bearer ",
 	},


### PR DESCRIPTION
## Summary

Add OpenRouter as a new LLM provider option, enabling users to route AI briefing requests through OpenRouter's unified API.

OpenRouter supports 100+ models including free tiers from OpenAI, Anthropic, Meta, Mistral, and others — giving users more flexibility in choosing models without managing multiple API keys.

## Changes

- **intel/intel.go**: Added ProviderOpenRouter constant and provider defaults:
  - Endpoint: `https://openrouter.ai/api/v1/chat/completions`
  - Default model: `openai/chatgpt-4o-latest`
  - Auth: Bearer token (OpenAI-compatible)
- **README.md**: Updated provider lists to include OpenRouter

## Test plan

- Set `llm_provider: openrouter` in config.yaml
- Add `OPENROUTER_API_KEY` env var or set `llm_api_key`
- Run watchtower and verify AI brief generates correctly

## Related

Closes #12
